### PR TITLE
Fix redis script cache key

### DIFF
--- a/lua/redis/main.lua
+++ b/lua/redis/main.lua
@@ -19,7 +19,7 @@ function _M.get_cached_script(red, ngx, script_name, script)
             ngx.log(ngx.ERR, "Failed to load script into Redis: ", err)
             return false
         end
-        redis_scripts_cache:set("leaky_bucket_sha", sha)
+        redis_scripts_cache:set(script_name, sha)
         script_sha = sha
     end
 

--- a/lua/tests/redis_main_test.lua
+++ b/lua/tests/redis_main_test.lua
@@ -1,0 +1,19 @@
+describe('redis main', function()
+    it('caches script using provided key', function()
+        local cache = {}
+        cache.get = function() return nil end
+        cache.set = function(_, key, val) cache.last_key = key; cache.last_val = val end
+        local ngx = {
+            shared = { redis_scripts_cache = cache },
+            log = function() end,
+            ERR = 'err'
+        }
+        local red = { script = function(_, _) return 'sha1' end }
+        package.loaded['redis.main'] = nil
+        local redis_main = require('redis.main')
+        local sha = redis_main.get_cached_script(red, ngx, 'my_script_sha', 'script')
+        assert.equals('sha1', sha)
+        assert.equals('my_script_sha', cache.last_key)
+        assert.equals('sha1', cache.last_val)
+    end)
+end)


### PR DESCRIPTION
## Summary
- fix script cache key in `lua/redis/main.lua`
- add regression test for redis script caching

## Testing
- `make tests` *(fails: docker-compose not found)*

------
https://chatgpt.com/codex/tasks/task_e_68419a3174dc8323a0373fb67e2e4ffd